### PR TITLE
feat: Narrow the scope of permissions for operator

### DIFF
--- a/deploy-templates/templates/secret_manager_own_rbac.yaml
+++ b/deploy-templates/templates/secret_manager_own_rbac.yaml
@@ -10,12 +10,9 @@ rules:
     resources:
       - secrets
     verbs:
-      - get
-      - list
-      - watch
       - create
-      - update
-      - patch
+    resourceNames:
+      - regcred
 
 ---
 


### PR DESCRIPTION
# Pull Request Template

## Description
In case the operator runs with secretsManager = 'own'
it has full access to the secret in all namespaces. We can narrow its permission to only create a secret with the name 'regcred'. This is all we need to manage regarded secrets.

Fixes #52 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
