### PR TITLE
feat: Remove CodebaseImageStream if Stage is removed

### DIFF
--- a/controllers/stage/chain/put_codebase_image_stream_test.go
+++ b/controllers/stage/chain/put_codebase_image_stream_test.go
@@ -90,6 +90,7 @@ func TestPutCodebaseImageStream_ShouldCreateCis(t *testing.T) {
 		cisResp)
 	assert.NoError(t, err)
 	assert.Equal(t, cisResp.Spec.ImageName, "stub-url/cb-name")
+	assert.NotNil(t, metaV1.GetControllerOf(cisResp))
 }
 
 func TestPutCodebaseImageStream_ShouldNotFindCDPipeline(t *testing.T) {
@@ -310,6 +311,7 @@ func TestPutCodebaseImageStream_ShouldNotFailWithExistingCbis(t *testing.T) {
 		},
 		cisResp)
 	assert.NoError(t, err)
+	assert.NotNil(t, metaV1.GetControllerOf(cisResp))
 }
 
 func TestPutCodebaseImageStream_ShouldCreateCisFromConfigMap(t *testing.T) {

--- a/hack/install-kuttl.sh
+++ b/hack/install-kuttl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.16.0/kubectl-kuttl_0.16.0_linux_x86_64
+sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.18.0/kubectl-kuttl_0.18.0_linux_x86_64
 sudo chmod +x /usr/local/bin/kubectl-kuttl
 export PATH=$PATH:/usr/local/bin

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -6,3 +6,4 @@ skipClusterDelete: false
 # hardcode namespace since we need to have predictable rolebindings
 namespace: edp
 timeout: 100
+parallel: 1

--- a/tests/e2e/capsule-feature/00-install-setup.yaml
+++ b/tests/e2e/capsule-feature/00-install-setup.yaml
@@ -1,9 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  # TestSuit namespace creation doesn't work, so we need to create this namespace manually
-  - command: kubectl create namespace edp
-    namespaced: false
   # install capsule
   - command: helm repo add projectcapsule https://projectcapsule.github.io/charts
     namespaced: false

--- a/tests/e2e/capsule-feature/99-cleanup.yaml
+++ b/tests/e2e/capsule-feature/99-cleanup.yaml
@@ -7,4 +7,3 @@ commands:
     # we have to uninstall helm since clusterwide resources, like ClusterRole are preserved
   - command: helm uninstall cd-pipeline-operator-e2e
     namespaced: true
-  - command: kubectl delete namespace edp


### PR DESCRIPTION
# Pull Request Template

## Description
Add Stage as a controller reference for the related CodebaseImageStream.

This change ensures that CodebaseImageStream is automatically removed when CodebaseBranch is deleted,
helping to avoid storing outdated CodebaseImageStreams.

Fixes #60 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- Unit tests.
- Manual testing.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes