### PR TITLE
feat: Add new deploy trigger type Auto-stable

### DIFF
--- a/api/v1/stage_types.go
+++ b/api/v1/stage_types.go
@@ -7,9 +7,17 @@ import (
 const (
 	StageCdPipelineLabelName = "app.edp.epam.com/cdPipelineName"
 	InCluster                = "in-cluster"
-)
 
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+	// TriggerTypeAutoDeploy indicates auto deploy with all latest tags for all applications.
+	TriggerTypeAutoDeploy = "Auto"
+
+	// TriggerTypeManual indicates manual deploy.
+	TriggerTypeManual = "Manual"
+
+	// TriggerTypeAutoStable indicates auto deploy with current tag passed to deployment + all stable tags for other applications.
+	// For applications without stable tag, the latest tag is used.
+	TriggerTypeAutoStable = "Auto-stable"
+)
 
 // StageSpec defines the desired state of Stage.
 // NOTE: for deleting the stage use stages order - delete only the latest stage.
@@ -29,7 +37,10 @@ type StageSpec struct {
 	// A description of a stage.
 	Description string `json:"description"`
 
-	// Stage deployment trigger type. E.g. Manual, Auto
+	// Stage deployment trigger type.
+	// +optional
+	// +kubebuilder:validation:Enum=Auto;Manual;Auto-stable
+	// +kubebuilder:default:="Manual"
 	TriggerType string `json:"triggerType"`
 
 	// The order to lay out Stages.
@@ -168,6 +179,18 @@ func (s *Stage) IsFirst() bool {
 
 func (s *Stage) InCluster() bool {
 	return s.Spec.ClusterName == InCluster
+}
+
+func (s *Stage) IsManualTriggerType() bool {
+	return s.Spec.TriggerType == TriggerTypeManual
+}
+
+func (s *Stage) IsAutoDeployTriggerType() bool {
+	return s.Spec.TriggerType == TriggerTypeAutoDeploy
+}
+
+func (s *Stage) IsAutoStableTriggerType() bool {
+	return s.Spec.TriggerType == TriggerTypeAutoStable
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/v2.edp.epam.com_stages.yaml
+++ b/config/crd/bases/v2.edp.epam.com_stages.yaml
@@ -153,7 +153,12 @@ spec:
                   The default TriggerTemplate is delivered using edp-tekton helm chart.
                 type: string
               triggerType:
-                description: Stage deployment trigger type. E.g. Manual, Auto
+                default: Manual
+                description: Stage deployment trigger type.
+                enum:
+                - Auto
+                - Manual
+                - Auto-stable
                 type: string
             required:
             - cdPipeline
@@ -161,7 +166,6 @@ spec:
             - name
             - order
             - qualityGates
-            - triggerType
             type: object
           status:
             description: StageStatus defines the observed state of Stage.

--- a/controllers/stage/chain/put_environment_label_to_codebase_image_streams_test.go
+++ b/controllers/stage/chain/put_environment_label_to_codebase_image_streams_test.go
@@ -17,7 +17,6 @@ import (
 	cdPipeApi "github.com/epam/edp-cd-pipeline-operator/v2/api/v1"
 	edpErr "github.com/epam/edp-cd-pipeline-operator/v2/pkg/error"
 	"github.com/epam/edp-cd-pipeline-operator/v2/pkg/util/cluster"
-	"github.com/epam/edp-cd-pipeline-operator/v2/pkg/util/consts"
 	codebaseApi "github.com/epam/edp-codebase-operator/v2/api/v1"
 )
 
@@ -40,7 +39,7 @@ func createStage(t *testing.T, order int, cdPipeline string) cdPipeApi.Stage {
 			Name:        name,
 			Order:       order,
 			CdPipeline:  cdPipeline,
-			TriggerType: consts.AutoDeployTriggerType,
+			TriggerType: cdPipeApi.TriggerTypeAutoDeploy,
 		},
 	}
 }
@@ -202,7 +201,7 @@ func TestPutEnvironmentLabelToCodebaseImageStreams_ServeRequest_CantGetImage(t *
 	assert.True(t, k8sErrors.IsNotFound(err))
 }
 
-func TestPutEnvironmentLabelToCodebaseImageStreams_ServeRequest_CantGetPreviousStageImage(t *testing.T) {
+func TestPutEnvironmentLabelToCodebaseImageStreams_ServeRequest_CantGetVerifiedStream(t *testing.T) {
 	stage := createStage(t, 1, cdPipeline)
 	prevStage := createStage(t, 0, cdPipeline)
 	prevStage.Name = previousStageName
@@ -238,5 +237,5 @@ func TestPutEnvironmentLabelToCodebaseImageStreams_ServeRequest_CantGetPreviousS
 	}
 
 	err := putEnvLabel.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), &stage)
-	assert.Equal(t, edpErr.CISNotFoundError(fmt.Sprintf("couldn't get %v codebase image stream", dockerImageName)), err)
+	assert.Equal(t, edpErr.CISNotFoundError("failed to get stub-cdPipeline-name-stub_name-stub-codebase-verified CodebaseImageStream"), err)
 }

--- a/controllers/stage/chain/remove_labels_from_codebase_docker_streams.go
+++ b/controllers/stage/chain/remove_labels_from_codebase_docker_streams.go
@@ -11,7 +11,6 @@ import (
 	cdPipeApi "github.com/epam/edp-cd-pipeline-operator/v2/api/v1"
 	"github.com/epam/edp-cd-pipeline-operator/v2/controllers/stage/chain/util"
 	"github.com/epam/edp-cd-pipeline-operator/v2/pkg/util/cluster"
-	"github.com/epam/edp-cd-pipeline-operator/v2/pkg/util/consts"
 )
 
 type RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate struct {
@@ -22,7 +21,7 @@ const dockerStreamsBeforeUpdateAnnotationKey = "deploy.edp.epam.com/docker-strea
 
 func (h RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate) ServeRequest(ctx context.Context, stage *cdPipeApi.Stage) error {
 	log := ctrl.LoggerFrom(ctx)
-	if consts.AutoDeployTriggerType != stage.Spec.TriggerType {
+	if stage.IsManualTriggerType() {
 		log.Info("Trigger type is not auto deploy, skipping")
 		return nil
 	}

--- a/controllers/stage/stage_controller_test.go
+++ b/controllers/stage/stage_controller_test.go
@@ -69,7 +69,7 @@ func TestTryToDeleteCDStage_DeletionTimestampIsZero(t *testing.T) {
 			Finalizers: []string{},
 		},
 		Spec: cdPipeApi.StageSpec{
-			TriggerType: consts.AutoDeployTriggerType,
+			TriggerType: cdPipeApi.TriggerTypeAutoDeploy,
 		},
 	}
 
@@ -111,7 +111,7 @@ func TestTryToDeleteCDStage_Success(t *testing.T) {
 		Spec: cdPipeApi.StageSpec{
 			Name:        name,
 			CdPipeline:  cdPipeline,
-			TriggerType: consts.AutoDeployTriggerType,
+			TriggerType: cdPipeApi.TriggerTypeAutoDeploy,
 			Order:       0,
 		},
 	}
@@ -261,7 +261,7 @@ func TestReconcileStage_Reconcile_Success(t *testing.T) {
 		Spec: cdPipeApi.StageSpec{
 			Name:        name,
 			CdPipeline:  cdPipeline,
-			TriggerType: consts.AutoDeployTriggerType,
+			TriggerType: cdPipeApi.TriggerTypeAutoDeploy,
 			Order:       0,
 		},
 	}
@@ -352,7 +352,7 @@ func TestReconcileStage_ReconcileReconcile_SetOwnerRef(t *testing.T) {
 		Spec: cdPipeApi.StageSpec{
 			Name:         name,
 			CdPipeline:   cdPipeline,
-			TriggerType:  consts.AutoDeployTriggerType,
+			TriggerType:  cdPipeApi.TriggerTypeAutoDeploy,
 			Order:        0,
 			QualityGates: []cdPipeApi.QualityGate{qualityGate},
 		},

--- a/deploy-templates/crds/v2.edp.epam.com_stages.yaml
+++ b/deploy-templates/crds/v2.edp.epam.com_stages.yaml
@@ -153,7 +153,12 @@ spec:
                   The default TriggerTemplate is delivered using edp-tekton helm chart.
                 type: string
               triggerType:
-                description: Stage deployment trigger type. E.g. Manual, Auto
+                default: Manual
+                description: Stage deployment trigger type.
+                enum:
+                - Auto
+                - Manual
+                - Auto-stable
                 type: string
             required:
             - cdPipeline
@@ -161,7 +166,6 @@ spec:
             - name
             - order
             - qualityGates
-            - triggerType
             type: object
           status:
             description: StageStatus defines the observed state of Stage.

--- a/docs/api.md
+++ b/docs/api.md
@@ -317,13 +317,6 @@ The order should start from 0, and the next stages should use +1 for the order.<
         </td>
         <td>true</td>
       </tr><tr>
-        <td><b>triggerType</b></td>
-        <td>string</td>
-        <td>
-          Stage deployment trigger type. E.g. Manual, Auto<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>cleanTemplate</b></td>
         <td>string</td>
         <td>
@@ -365,6 +358,16 @@ Default value is "deploy" which means that default TriggerTemplate will be used.
 The default TriggerTemplate is delivered using edp-tekton helm chart.<br/>
           <br/>
             <i>Default</i>: deploy<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>triggerType</b></td>
+        <td>enum</td>
+        <td>
+          Stage deployment trigger type.<br/>
+          <br/>
+            <i>Enum</i>: Auto, Manual, Auto-stable<br/>
+            <i>Default</i>: Manual<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/pkg/util/consts/consts.go
+++ b/pkg/util/consts/consts.go
@@ -6,6 +6,4 @@ const (
 	FinishedStatus = "created"
 
 	FailedStatus = "failed"
-
-	AutoDeployTriggerType = "Auto"
 )


### PR DESCRIPTION
# Pull Request Template

## Description
`Auto-stable` trigger type will be used to deploy the newly built application tag with all other stable applications.

Fixes #75 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Unit test

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
