### PR TITLE
fix: Resolve repo path issue in ApplicationSet with GitServers (#86)

### DIFF
--- a/tests/e2e/capsule-feature/03-assert-cdpipeline-and-stages.yaml
+++ b/tests/e2e/capsule-feature/03-assert-cdpipeline-and-stages.yaml
@@ -255,6 +255,7 @@ spec:
             imageRepository: registry.host.local/registry-space/test
             imageTag: NaN
             namespace: edp-mypipeline-dev
+            repoURL: ssh://git@gerrit-dev:30000/test
             stage: dev
             versionType: default
             customValues: false
@@ -264,6 +265,7 @@ spec:
             imageRepository: registry.host.local/registry-space/test
             imageTag: NaN
             namespace: custom-namespace
+            repoURL: ssh://git@gerrit-dev:30000/test
             stage: qa
             versionType: default
             customValues: false
@@ -298,7 +300,7 @@ spec:
               value: '{{ .imageRepository }}'
           releaseName: '{{ .codebase }}'
         path: deploy-templates
-        repoURL: ssh://git@gerrit-dev:30000/{{ .gitUrlPath }}
+        repoURL: '{{ .repoURL }}'
         targetRevision: >-
           {{ if eq .versionType "edp" }}build/{{ .imageTag }}{{ else }}{{
           .imageTag }}{{ end }}


### PR DESCRIPTION
# Pull Request Template

## Description
Fix invalid repository URLs in ApplicationSet that caused deployment failures. The issue occurred in two cases:
- Applications with different GitServers
- Switching a CDPipeline application to one with a different GitServer

This happened because repository URLs were set in the template, which was never updated. Only the repo path was dynamic in the generators section. Moved complete repository URLs to the generators to make them dynamic and resolve the issue.

To fix existing ApplicationSets, remove those with invalid repository URLs. The operator will recreate them with valid URLs.

Fixes #86 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Unit tests
- Manual testing

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.