### PR TITLE
feat: Add Stage CR namespace validation for multitenancy (#96)

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,5 +1,19 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: manager-role

--- a/deploy-templates/templates/validation_webhook_rbac.yaml
+++ b/deploy-templates/templates/validation_webhook_rbac.yaml
@@ -13,6 +13,14 @@ rules:
     - get
     - update
     - patch
+- apiGroups:
+    - ""
+  resources:
+    - namespaces
+  verbs:
+    - get
+    - list
+    - watch
 
 ---
 


### PR DESCRIPTION
# Pull Request Template

## Description
This change adds validation for the `Stage.spec.namespace` field to avoid conflicts when Stage CRs from different namespaces can point to the same namespace.
Before creating the Stage, the webhook checks namespaces and returns an error if the namespace(with tenant label) already exists in the cluster.

Fixes #96 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Unit test.
- Manual testing.

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.