### PR TITLE
feat: Improve namespace deletion handling (#114)

### DIFF
--- a/controllers/stage/chain/delete_namespace.go
+++ b/controllers/stage/chain/delete_namespace.go
@@ -8,6 +8,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cdPipeApi "github.com/epam/edp-cd-pipeline-operator/v2/api/v1"
 )
@@ -19,19 +20,26 @@ type DeleteNamespace struct {
 func (h DeleteNamespace) ServeRequest(ctx context.Context, stage *cdPipeApi.Stage) error {
 	l := ctrl.LoggerFrom(ctx).WithValues("namespace", stage.Spec.Namespace)
 
-	ns := &corev1.Namespace{
-		ObjectMeta: metaV1.ObjectMeta{
-			Name: stage.Spec.Namespace,
-		},
-	}
-
-	if err := h.multiClusterClient.Delete(ctx, ns); err != nil {
+	if err := h.multiClusterClient.Get(ctx, client.ObjectKey{Name: stage.Spec.Namespace}, &corev1.Namespace{}); err != nil {
 		if apierrors.IsNotFound(err) {
 			l.Info("Namespace has already been deleted")
 
 			return nil
 		}
 
+		return fmt.Errorf("failed to get namespace: %w", err)
+	}
+
+	if err := client.IgnoreNotFound(
+		h.multiClusterClient.Delete(
+			ctx,
+			&corev1.Namespace{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name: stage.Spec.Namespace,
+				},
+			},
+		),
+	); err != nil {
 		return fmt.Errorf("failed to delete namespace: %w", err)
 	}
 


### PR DESCRIPTION
# Pull Request Template

## Description
In case if namespace doesn't exist we get error trying to delete it. We have an error because Capsule allows the operators to delete only the existing namespace.
Add check if the namespace exists before removing it.

Fixes #114 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Manual testing

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.