### PR TITLE
feat: Add validation webhook for protected resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ validate-docs: api-docs helm-docs  ## Validate helm and api docs
 	@git diff -s --exit-code docs/api.md || (echo " Run 'make api-docs' to address the issue." && git diff && exit 1)
 
 # Run tests
-test: fmt vet
+test: fmt vet envtest
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	go test ./... -coverprofile=coverage.out `go list ./...`
 
 ## Run e2e tests. Requires kind with running cluster and kuttl tool.
@@ -208,3 +209,9 @@ MOCKERY = $(LOCALBIN)/mockery
 .PHONY: mockery
 mockery: ## Download mockery locally if necessary.
 	$(call go-get-tool,$(MOCKERY),github.com/vektra/mockery/v2,v2.46.3)
+
+ENVTEST=$(LOCALBIN)/setup-envtest
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,release-0.16)

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -10,6 +10,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-v2-edp-epam-com-v1-cdpipeline
+  failurePolicy: Fail
+  name: cdpipeline.epam.com
+  rules:
+  - apiGroups:
+    - v2.edp.epam.com
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - cdpipelines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-v2-edp-epam-com-v1-stage
   failurePolicy: Fail
   name: stage.epam.com
@@ -21,6 +41,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - stages
   sideEffects: None

--- a/deploy-templates/templates/validation_webhook.yaml
+++ b/deploy-templates/templates/validation_webhook.yaml
@@ -7,6 +7,33 @@ metadata:
   name: edp-cd-pipeline-operator-validating-webhook-configuration-{{ .Release.Namespace }}
 webhooks:
 - admissionReviewVersions:
+    - v1
+  clientConfig:
+    service:
+      name: edp-cd-pipeline-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-v2-edp-epam-com-v1-cdpipeline
+  failurePolicy: Fail
+  name: cdpipeline.epam.com
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+          - {{ .Release.Namespace }}
+  rules:
+    - apiGroups:
+      - v2.edp.epam.com
+      apiVersions:
+        - v1
+      operations:
+        - UPDATE
+        - DELETE
+      resources:
+        - cdpipelines
+      scope: Namespaced
+  sideEffects: None
+- admissionReviewVersions:
   - v1
   clientConfig:
     service:
@@ -29,6 +56,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - stages
     scope: Namespaced

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/epam/edp-codebase-operator/v2 v2.21.0
 	github.com/epam/edp-common v0.0.0-20230710145648-344bbce4120e
 	github.com/epam/edp-component-operator v0.13.0
-	github.com/go-logr/logr v1.3.0
+	github.com/go-logr/logr v1.4.1
+	github.com/onsi/ginkgo/v2 v2.19.0
+	github.com/onsi/gomega v1.34.1
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
@@ -113,6 +115,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-redis/cache/v9 v9.0.0 // indirect
+	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -125,6 +128,7 @@ require (
 	github.com/google/go-github/v53 v53.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
@@ -191,7 +195,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
 	google.golang.org/grpc v1.59.0 // indirect
-	google.golang.org/protobuf v1.33.0 // indirect
+	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
-github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
 github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -177,6 +177,8 @@ github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+
 github.com/go-redis/cache/v9 v9.0.0 h1:0thdtFo0xJi0/WXbRVu8B066z8OvVymXTJGaXrVWnN0=
 github.com/go-redis/cache/v9 v9.0.0/go.mod h1:cMwi1N8ASBOufbIvk7cdXe2PbPjK/WMRL95FFHWsSgI=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
+github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
@@ -221,6 +223,8 @@ github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 h1:k7nVchz72niMH6YLQNvHSdIE7iqsQxK1P41mySCvssg=
+github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -321,8 +325,9 @@ github.com/onsi/ginkgo/v2 v2.1.6/go.mod h1:MEH45j8TBi6u9BMogfbp0stKC5cdGjumZj5Y7
 github.com/onsi/ginkgo/v2 v2.3.0/go.mod h1:Eew0uilEqZmIEZr8JrvYlvOM7Rr6xzTmMV8AyFNU9d0=
 github.com/onsi/ginkgo/v2 v2.4.0/go.mod h1:iHkDK1fKGcBoEHT5W7YBq4RFWaQulw+caOMkAt4OrFo=
 github.com/onsi/ginkgo/v2 v2.5.0/go.mod h1:Luc4sArBICYCS8THh8v3i3i5CuSZO+RaQRaJoeNwomw=
-github.com/onsi/ginkgo/v2 v2.7.0 h1:/XxtEV3I3Eif/HobnVx9YmJgk8ENdRsuUmM+fLCFNow=
 github.com/onsi/ginkgo/v2 v2.7.0/go.mod h1:yjiuMwPokqY1XauOgju45q3sJt6VzQ/Fict1LFVcsAo=
+github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA=
+github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
@@ -656,8 +661,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
+google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/webhook/cdpipeline_webhook.go
+++ b/pkg/webhook/cdpipeline_webhook.go
@@ -1,0 +1,60 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	pipelineApi "github.com/epam/edp-cd-pipeline-operator/v2/api/v1"
+)
+
+//+kubebuilder:webhook:path=/validate-v2-edp-epam-com-v1-cdpipeline,mutating=false,failurePolicy=fail,sideEffects=None,groups=v2.edp.epam.com,resources=cdpipelines,verbs=update;delete,versions=v1,name=cdpipeline.epam.com,admissionReviewVersions=v1
+
+// CDPipelineValidationWebhook is a webhook for validating CDPipeline CRD.
+type CDPipelineValidationWebhook struct {
+	client client.Client
+}
+
+// NewCDPipelineValidationWebhook creates a new webhook for validating CDPipeline CR.
+func NewCDPipelineValidationWebhook(k8sClient client.Client) *CDPipelineValidationWebhook {
+	return &CDPipelineValidationWebhook{client: k8sClient}
+}
+
+// SetupWebhookWithManager sets up the webhook with the manager for CDPipeline CR.
+func (r *CDPipelineValidationWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	err := ctrl.NewWebhookManagedBy(mgr).
+		For(&pipelineApi.CDPipeline{}).
+		WithValidator(r).
+		Complete()
+	if err != nil {
+		return fmt.Errorf("failed to build CDPipeline validation webhook: %w", err)
+	}
+
+	return nil
+}
+
+var _ webhook.CustomValidator = &CDPipelineValidationWebhook{}
+
+// ValidateCreate is a webhook for validating the creation of the CDPipeline CR.
+func (*CDPipelineValidationWebhook) ValidateCreate(_ context.Context, _ runtime.Object) error {
+	return nil
+}
+
+// ValidateUpdate is a webhook for validating the updating of the CDPipeline CR.
+func (*CDPipelineValidationWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) error {
+	pipe, ok := newObj.(*pipelineApi.CDPipeline)
+	if !ok {
+		return nil
+	}
+
+	return checkResourceProtectionFromModificationOnUpdate(oldObj, pipe)
+}
+
+// ValidateDelete is a webhook for validating the deleting of the CDPipeline CR.
+func (*CDPipelineValidationWebhook) ValidateDelete(_ context.Context, obj runtime.Object) error {
+	return checkResourceProtectionFromModificationOnDelete(obj)
+}

--- a/pkg/webhook/cdpipeline_webhook_test.go
+++ b/pkg/webhook/cdpipeline_webhook_test.go
@@ -1,0 +1,193 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	pipelineApi "github.com/epam/edp-cd-pipeline-operator/v2/api/v1"
+)
+
+func TestCDPipelineValidationWebhook_ValidateUpdate(t *testing.T) {
+	cl := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+
+	type args struct {
+		oldObj runtime.Object
+		newObj runtime.Object
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "validating CDPipeline update with protected label",
+			args: args{
+				oldObj: &pipelineApi.CDPipeline{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cd-pipeline",
+						Labels: map[string]string{
+							protectedLabel: fmt.Sprintf("%s-%s", updateOperation, deleteOperation),
+						},
+					},
+					Spec: pipelineApi.CDPipelineSpec{
+						Description: "cd-pipeline",
+					},
+				},
+				newObj: &pipelineApi.CDPipeline{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cd-pipeline",
+						Labels: map[string]string{
+							protectedLabel: fmt.Sprintf("%s-%s", updateOperation, deleteOperation),
+						},
+					},
+					Spec: pipelineApi.CDPipelineSpec{
+						Description: "cd-pipeline 2",
+					},
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "validating CDPipeline update without protected label in new object",
+			args: args{
+				oldObj: &pipelineApi.CDPipeline{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cd-pipeline",
+						Labels: map[string]string{
+							protectedLabel: fmt.Sprintf("%s-%s", updateOperation, deleteOperation),
+						},
+					},
+					Spec: pipelineApi.CDPipelineSpec{
+						Description: "cd-pipeline",
+					},
+				},
+				newObj: &pipelineApi.CDPipeline{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cd-pipeline",
+					},
+					Spec: pipelineApi.CDPipelineSpec{
+						Description: "cd-pipeline 2",
+					},
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
+			name: "validating CDPipeline update without protected label in old object",
+			args: args{
+				oldObj: &pipelineApi.CDPipeline{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cd-pipeline",
+					},
+					Spec: pipelineApi.CDPipelineSpec{
+						Description: "cd-pipeline",
+					},
+				},
+				newObj: &pipelineApi.CDPipeline{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cd-pipeline",
+						Labels: map[string]string{
+							protectedLabel: fmt.Sprintf("%s-%s", updateOperation, deleteOperation),
+						},
+					},
+					Spec: pipelineApi.CDPipelineSpec{
+						Description: "cd-pipeline 2",
+					},
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "validating CDPipeline update with protected label(delete)",
+			args: args{
+				oldObj: &pipelineApi.CDPipeline{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cd-pipeline",
+						Labels: map[string]string{
+							protectedLabel: deleteOperation,
+						},
+					},
+					Spec: pipelineApi.CDPipelineSpec{
+						Description: "cd-pipeline",
+					},
+				},
+				newObj: &pipelineApi.CDPipeline{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cd-pipeline",
+						Labels: map[string]string{
+							protectedLabel: deleteOperation,
+						},
+					},
+					Spec: pipelineApi.CDPipelineSpec{
+						Description: "cd-pipeline 2",
+					},
+				},
+			},
+			wantErr: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cd := NewCDPipelineValidationWebhook(cl)
+			tt.wantErr(t, cd.ValidateUpdate(context.Background(), tt.args.oldObj, tt.args.newObj))
+		})
+	}
+}
+
+func TestCDPipelineValidationWebhook_ValidateDelete(t *testing.T) {
+	cl := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+
+	type args struct {
+		obj runtime.Object
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "validating CDPipeline delete with protected label",
+			args: args{
+				obj: &pipelineApi.CDPipeline{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cd-pipeline",
+						Labels: map[string]string{
+							protectedLabel: deleteOperation,
+						},
+					},
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "validating CDPipeline delete without protected label",
+			args: args{
+				obj: &pipelineApi.CDPipeline{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cd-pipeline",
+						Labels: map[string]string{
+							protectedLabel: updateOperation,
+						},
+					},
+				},
+			},
+			wantErr: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cd := NewCDPipelineValidationWebhook(cl)
+			tt.wantErr(t, cd.ValidateDelete(context.Background(), tt.args.obj))
+		})
+	}
+}

--- a/pkg/webhook/protected_label.go
+++ b/pkg/webhook/protected_label.go
@@ -1,0 +1,60 @@
+package webhook
+
+import (
+	"errors"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"slices"
+
+	pipelineApi "github.com/epam/edp-cd-pipeline-operator/v2/api/v1"
+)
+
+const (
+	protectedLabel  = "app.edp.epam.com/edit-protection"
+	deleteOperation = "delete"
+	updateOperation = "update"
+)
+
+func hasProtectedLabel(obj runtime.Object, operation string) bool {
+	o, ok := obj.(metaV1.Object)
+	if !ok {
+		return false
+	}
+
+	return o.GetLabels()[protectedLabel] != "" &&
+		slices.Contains(strings.Split(o.GetLabels()[protectedLabel], "-"), operation)
+}
+
+func isSpecUpdated(oldObj, newObj runtime.Object) bool {
+	switch old := oldObj.(type) {
+	case *pipelineApi.Stage:
+		if newStage, ok := newObj.(*pipelineApi.Stage); ok {
+			return !equality.Semantic.DeepEqual(old.Spec, newStage.Spec)
+		}
+	case *pipelineApi.CDPipeline:
+		if newPipeline, ok := newObj.(*pipelineApi.CDPipeline); ok {
+			return !equality.Semantic.DeepEqual(old.Spec, newPipeline.Spec)
+		}
+	}
+
+	return false
+}
+
+func checkResourceProtectionFromModificationOnDelete(obj runtime.Object) error {
+	if hasProtectedLabel(obj, deleteOperation) {
+		return errors.New("resource contains label that protects it from deletion")
+	}
+
+	return nil
+}
+
+func checkResourceProtectionFromModificationOnUpdate(oldObj, newObj runtime.Object) error {
+	if hasProtectedLabel(newObj, updateOperation) && isSpecUpdated(oldObj, newObj) {
+		return errors.New("resource contains label that protects it from modification")
+	}
+
+	return nil
+}

--- a/pkg/webhook/stage_webhook.go
+++ b/pkg/webhook/stage_webhook.go
@@ -17,7 +17,7 @@ import (
 
 const listLimit = 1000
 
-//+kubebuilder:webhook:path=/validate-v2-edp-epam-com-v1-stage,mutating=false,failurePolicy=fail,sideEffects=None,groups=v2.edp.epam.com,resources=stages,verbs=create;update,versions=v1,name=stage.epam.com,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-v2-edp-epam-com-v1-stage,mutating=false,failurePolicy=fail,sideEffects=None,groups=v2.edp.epam.com,resources=stages,verbs=create;update;delete,versions=v1,name=stage.epam.com,admissionReviewVersions=v1
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
 // StageValidationWebhook is a webhook for validating Stage CRD.
@@ -60,14 +60,13 @@ func (r *StageValidationWebhook) ValidateCreate(ctx context.Context, obj runtime
 }
 
 // ValidateUpdate is a webhook for validating the updating of the Stage CR.
-func (*StageValidationWebhook) ValidateUpdate(_ context.Context, _, _ runtime.Object) error {
-	return nil
+func (*StageValidationWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) error {
+	return checkResourceProtectionFromModificationOnUpdate(oldObj, newObj)
 }
 
 // ValidateDelete is a webhook for validating the deleting of the Stage CR.
-// It is skipped for now. Add kubebuilder:webhook:verbs=delete to enable it.
-func (*StageValidationWebhook) ValidateDelete(_ context.Context, _ runtime.Object) error {
-	return nil
+func (*StageValidationWebhook) ValidateDelete(_ context.Context, obj runtime.Object) error {
+	return checkResourceProtectionFromModificationOnDelete(obj)
 }
 
 func (r *StageValidationWebhook) uniqueTargetNamespaces(ctx context.Context, stage *pipelineApi.Stage) error {

--- a/pkg/webhook/stage_webhook_test.go
+++ b/pkg/webhook/stage_webhook_test.go
@@ -2,12 +2,13 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -33,7 +34,7 @@ func TestStageValidationWebhook_ValidateCreate(t *testing.T) {
 		{
 			name: "valid stage, no namespace conflict",
 			obj: &pipelineApi.Stage{
-				ObjectMeta: metaV1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "stage1",
 					Namespace: "default",
 				},
@@ -46,7 +47,7 @@ func TestStageValidationWebhook_ValidateCreate(t *testing.T) {
 			},
 			client: func(t *testing.T) client.Client {
 				stageWithDifferentTargetNs := &pipelineApi.Stage{
-					ObjectMeta: metaV1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "stage2",
 						Namespace: "default",
 					},
@@ -59,7 +60,7 @@ func TestStageValidationWebhook_ValidateCreate(t *testing.T) {
 				}
 
 				stageWithDifferentClusterButSameTargetNs := &pipelineApi.Stage{
-					ObjectMeta: metaV1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "stage3",
 						Namespace: "default",
 					},
@@ -81,7 +82,7 @@ func TestStageValidationWebhook_ValidateCreate(t *testing.T) {
 		{
 			name: "namespace conflict",
 			obj: &pipelineApi.Stage{
-				ObjectMeta: metaV1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "stage1",
 					Namespace: "default",
 				},
@@ -94,7 +95,7 @@ func TestStageValidationWebhook_ValidateCreate(t *testing.T) {
 			},
 			client: func(t *testing.T) client.Client {
 				stageWithSameTargetNs := &pipelineApi.Stage{
-					ObjectMeta: metaV1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "stage2",
 						Namespace: "default",
 					},
@@ -118,7 +119,7 @@ func TestStageValidationWebhook_ValidateCreate(t *testing.T) {
 		{
 			name: "namespace already used in the cluster",
 			obj: &pipelineApi.Stage{
-				ObjectMeta: metaV1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "stage1",
 					Namespace: "default",
 				},
@@ -131,7 +132,7 @@ func TestStageValidationWebhook_ValidateCreate(t *testing.T) {
 			},
 			client: func(t *testing.T) client.Client {
 				ns1 := &corev1.Namespace{
-					ObjectMeta: metaV1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "ns1",
 						Labels: map[string]string{
 							util.TenantLabelName: "ns1",
@@ -174,13 +175,121 @@ func TestStageValidationWebhook_ValidateCreate(t *testing.T) {
 }
 
 func TestStageValidationWebhook_ValidateUpdate(t *testing.T) {
-	r := NewStageValidationWebhook(fake.NewClientBuilder().Build())
+	cl := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
 
-	assert.NoError(t, r.ValidateUpdate(context.Background(), &pipelineApi.Stage{}, &pipelineApi.Stage{}))
+	type args struct {
+		oldObj runtime.Object
+		newObj runtime.Object
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "validating Stage update with protected label",
+			args: args{
+				oldObj: &pipelineApi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "stage",
+						Labels: map[string]string{
+							protectedLabel: fmt.Sprintf("%s-%s", updateOperation, deleteOperation),
+						},
+					},
+					Spec: pipelineApi.StageSpec{
+						Description: "stage",
+					},
+				},
+				newObj: &pipelineApi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "stage",
+						Labels: map[string]string{
+							protectedLabel: fmt.Sprintf("%s-%s", updateOperation, deleteOperation),
+						},
+					},
+					Spec: pipelineApi.StageSpec{
+						Description: "stage 2",
+					},
+				},
+			},
+			wantErr: require.Error,
+		},
+		{
+			name: "validating Stage update without protected label",
+			args: args{
+				oldObj: &pipelineApi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "stage",
+					},
+					Spec: pipelineApi.StageSpec{
+						Description: "stage",
+					},
+				},
+				newObj: &pipelineApi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "stage",
+					},
+					Spec: pipelineApi.StageSpec{
+						Description: "stage 2",
+					},
+				},
+			},
+			wantErr: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cd := NewStageValidationWebhook(cl)
+			tt.wantErr(t, cd.ValidateUpdate(context.Background(), tt.args.oldObj, tt.args.newObj))
+		})
+	}
 }
 
 func TestStageValidationWebhook_ValidateDelete(t *testing.T) {
-	r := NewStageValidationWebhook(fake.NewClientBuilder().Build())
+	cl := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
 
-	assert.NoError(t, r.ValidateDelete(context.Background(), &pipelineApi.Stage{}))
+	type args struct {
+		obj runtime.Object
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "validating Stage delete with protected label",
+			args: args{
+				obj: &pipelineApi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "stage",
+						Labels: map[string]string{
+							protectedLabel: deleteOperation,
+						},
+					},
+				},
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "validating Stage delete without protected label",
+			args: args{
+				obj: &pipelineApi.Stage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "stage",
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := NewStageValidationWebhook(cl)
+			tt.wantErr(t, st.ValidateDelete(context.Background(), tt.args.obj))
+		})
+	}
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -15,9 +15,12 @@ func RegisterValidationWebHook(ctx context.Context, mgr ctrl.Manager, namespace 
 		return fmt.Errorf("failed to populate certificates: %w", err)
 	}
 
-	stageWebHook := NewStageValidationWebhook(mgr.GetClient())
-	if err := stageWebHook.SetupWebhookWithManager(mgr); err != nil {
-		return fmt.Errorf("failed to create webhook: %w", err)
+	if err := NewStageValidationWebhook(mgr.GetClient()).SetupWebhookWithManager(mgr); err != nil {
+		return fmt.Errorf("failed to create Stage webhook: %w", err)
+	}
+
+	if err := NewCDPipelineValidationWebhook(mgr.GetClient()).SetupWebhookWithManager(mgr); err != nil {
+		return fmt.Errorf("failed to create CDpipeline webhook: %w", err)
 	}
 
 	return nil

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -1,0 +1,66 @@
+package webhook
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	pipelineApi "github.com/epam/edp-cd-pipeline-operator/v2/api/v1"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.Background())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	sc := runtime.NewScheme()
+	Expect(scheme.AddToScheme(sc)).NotTo(HaveOccurred())
+	Expect(pipelineApi.AddToScheme(sc)).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: sc})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1,0 +1,76 @@
+package webhook
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("webhooks registration", func() {
+	When("ValidatingWebhookConfiguration exists", func() {
+		BeforeEach(func() {
+			By("creating ValidatingWebhookConfiguration")
+			webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: ctrl.ObjectMeta{
+					Name: getValidationWebHookName("default"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, webhook)).ToNot(HaveOccurred())
+		})
+		AfterEach(func() {
+			webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: ctrl.ObjectMeta{
+					Name: getValidationWebHookName("default"),
+				},
+			}
+			err := ctrlclient.IgnoreNotFound(k8sClient.Delete(ctx, webhook))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should register validation webhooks", func() {
+			By("creating manager")
+			k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+				Scheme:             k8sClient.Scheme(),
+				MetricsBindAddress: "0",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("registering validation webhooks")
+			err = RegisterValidationWebHook(ctx, k8sManager, "default")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		When("scheme doesn't contain cdpipeline types", func() {
+			It("should return error", func() {
+				By("creating manager")
+				k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+					Scheme:             scheme.Scheme,
+					MetricsBindAddress: "0",
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("registering validation webhooks")
+				err = RegisterValidationWebHook(ctx, k8sManager, "default")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+	When("MutatingWebhookConfiguration doesn't exist", func() {
+		It("should return error", func() {
+			By("creating manager")
+			k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+				Scheme:             k8sClient.Scheme(),
+				MetricsBindAddress: "0",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("registering mutation webhooks")
+			err = RegisterValidationWebHook(ctx, k8sManager, "default")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,4 +3,4 @@ sonar.projectName=cd-pipeline-operator
 sonar.projectVersion=1.0
 sonar.go.coverage.reportPaths=coverage.out
 sonar.test.inclusions=**/*_test.go
-sonar.exclusions=**/cache/**,**/config/**,**/deploy-templates/**,**/*_controller.go,**/zz_generated.deepcopy.go,**/*_types.go,**/factory.go,**/*_mock.go,**/*.groovy,**/.github/**,**/api/**,**/tests/**,**/hack/**
+sonar.exclusions=**/cache/**,**/config/**,**/deploy-templates/**,**/*_controller.go,**/zz_generated.deepcopy.go,**/*_types.go,**/factory.go,**/*_mock.go,**/*.groovy,**/.github/**,**/api/**,**/tests/**,**/hack/**,main.go


### PR DESCRIPTION
# Pull Request Template

## Description
To protect resources from deletion/updating added label 
`app.edp.epam.com/edit-protection`.
The label can have values: `delete` `update` `delete-update`

Fixes #113

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Unit tests
- Manual testing

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.
