### PR TITLE
feat: Use label selector for CodebaseImageStream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ tags
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 kubeconfig
+.DS_Store

--- a/controllers/stage/chain/delete_environment_label_from_codebase_image_streams.go
+++ b/controllers/stage/chain/delete_environment_label_from_codebase_image_streams.go
@@ -45,7 +45,7 @@ func (h DeleteEnvironmentLabelFromCodebaseImageStreams) deleteEnvironmentLabel(c
 	}
 
 	for _, name := range pipe.Spec.InputDockerStreams {
-		stream, err := cluster.GetCodebaseImageStream(h.client, name, stage.Namespace)
+		stream, err := cluster.GetCodebaseImageStreamByCodebaseBaseBranchName(ctx, h.client, name, stage.Namespace)
 		if err != nil {
 			return fmt.Errorf("failed to get %s codebase image stream: %w", name, err)
 		}

--- a/controllers/stage/chain/put_codebase_image_stream_test.go
+++ b/controllers/stage/chain/put_codebase_image_stream_test.go
@@ -17,6 +17,7 @@ import (
 
 	cdPipeApi "github.com/epam/edp-cd-pipeline-operator/v2/api/v1"
 	"github.com/epam/edp-cd-pipeline-operator/v2/pkg/platform"
+	"github.com/epam/edp-cd-pipeline-operator/v2/pkg/util/cluster"
 	codebaseApi "github.com/epam/edp-codebase-operator/v2/api/v1"
 	componentApi "github.com/epam/edp-component-operator/api/v1"
 )
@@ -63,6 +64,9 @@ func TestPutCodebaseImageStream_ShouldCreateCis(t *testing.T) {
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      "cbis-name",
 			Namespace: "stub-namespace",
+			Labels: map[string]string{
+				cluster.CodebaseImageStreamCodebaseBranchLabel: "cbis-name",
+			},
 		},
 		Spec: codebaseApi.CodebaseImageStreamSpec{
 			Codebase: "cb-name",
@@ -277,6 +281,9 @@ func TestPutCodebaseImageStream_ShouldNotFailWithExistingCbis(t *testing.T) {
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      "cbis-name",
 			Namespace: "stub-namespace",
+			Labels: map[string]string{
+				cluster.CodebaseImageStreamCodebaseBranchLabel: "cbis-name",
+			},
 		},
 		Spec: codebaseApi.CodebaseImageStreamSpec{
 			Codebase: "cb-name",
@@ -315,7 +322,6 @@ func TestPutCodebaseImageStream_ShouldNotFailWithExistingCbis(t *testing.T) {
 		},
 		cisResp)
 	assert.NoError(t, err)
-	assert.NotNil(t, metaV1.GetControllerOf(cisResp))
 }
 
 func TestPutCodebaseImageStream_ShouldCreateCisFromConfigMap(t *testing.T) {
@@ -360,6 +366,9 @@ func TestPutCodebaseImageStream_ShouldCreateCisFromConfigMap(t *testing.T) {
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      "cbis-name",
 			Namespace: "stub-namespace",
+			Labels: map[string]string{
+				cluster.CodebaseImageStreamCodebaseBranchLabel: "cbis-name",
+			},
 		},
 		Spec: codebaseApi.CodebaseImageStreamSpec{
 			Codebase: "cb-name",

--- a/controllers/stage/chain/put_environment_label_to_codebase_image_streams.go
+++ b/controllers/stage/chain/put_environment_label_to_codebase_image_streams.go
@@ -40,7 +40,7 @@ func (h PutEnvironmentLabelToCodebaseImageStreams) ServeRequest(ctx context.Cont
 	}
 
 	for _, name := range pipe.Spec.InputDockerStreams {
-		stream, err := cluster.GetCodebaseImageStream(h.client, name, stage.Namespace)
+		stream, err := cluster.GetCodebaseImageStreamByCodebaseBaseBranchName(ctx, h.client, name, stage.Namespace)
 		if err != nil {
 			return fmt.Errorf("couldn't get %s codebase image stream: %w", name, err)
 		}

--- a/controllers/stage/chain/remove_labels_from_codebase_docker_streams.go
+++ b/controllers/stage/chain/remove_labels_from_codebase_docker_streams.go
@@ -42,9 +42,9 @@ func (h RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate) ServeRequest
 
 	streams := strings.Split(annotations, ",")
 	for _, v := range streams {
-		stream, err := cluster.GetCodebaseImageStream(h.client, v, stage.Namespace)
+		stream, err := cluster.GetCodebaseImageStreamByCodebaseBaseBranchName(ctx, h.client, v, stage.Namespace)
 		if err != nil {
-			return fmt.Errorf("failed to get %v codebase image stream: %w", stream, err)
+			return fmt.Errorf("failed to get %v codebase image stream: %w", v, err)
 		}
 
 		env := fmt.Sprintf("%v/%v", pipe.Name, stage.Spec.Name)

--- a/hack/install-kuttl.sh
+++ b/hack/install-kuttl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.19.0/kubectl-kuttl_0.19.0_linux_x86_64
+sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.22.0/kubectl-kuttl_0.22.0_linux_x86_64
 sudo chmod +x /usr/local/bin/kubectl-kuttl
 export PATH=$PATH:/usr/local/bin

--- a/tests/e2e/capsule-feature/03-assert-cdpipeline-and-stages.yaml
+++ b/tests/e2e/capsule-feature/03-assert-cdpipeline-and-stages.yaml
@@ -253,9 +253,9 @@ spec:
             gitUrlPath: test
             imageRepository: registry.host.local/registry-space/test
             imageTag: NaN
-            namespace: edp-mypipeline-dev
+            namespace: custom-namespace
             repoURL: ssh://git@gerrit-dev:30000/test
-            stage: dev
+            stage: qa
             versionType: default
             customValues: false
           - cluster: in-cluster
@@ -263,9 +263,9 @@ spec:
             gitUrlPath: test
             imageRepository: registry.host.local/registry-space/test
             imageTag: NaN
-            namespace: custom-namespace
+            namespace: edp-mypipeline-dev
             repoURL: ssh://git@gerrit-dev:30000/test
-            stage: qa
+            stage: dev
             versionType: default
             customValues: false
         template:

--- a/tests/e2e/capsule-feature/03-create-cdpipeline-and-stages.yaml
+++ b/tests/e2e/capsule-feature/03-create-cdpipeline-and-stages.yaml
@@ -130,6 +130,8 @@ apiVersion: v2.edp.epam.com/v1
 kind: CodebaseImageStream
 metadata:
   name: test-main
+  labels:
+    app.edp.epam.com/cbis-codebasebranch: test-main
 spec:
   codebase: test
   imageName: registry.host.local/registry-space/test


### PR DESCRIPTION
# Pull Request Template

## Description
This change is due to the reworking of the relation
between CodebaseBranch and CodebaseImageStream.
https://github.com/epam/edp-codebase-operator/issues/198 The CodebaseImageStream now has a label
that allows it to select CodebaseBranch.

Fixes #135 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
- Unit test
- Manual testing

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.