### PR TITLE
EPMDEDP-17108: fix: Purge stale environment label from CodebaseImageStream

### DIFF
--- a/internal/controller/stage/chain/remove_labels_from_codebase_docker_streams.go
+++ b/internal/controller/stage/chain/remove_labels_from_codebase_docker_streams.go
@@ -3,63 +3,151 @@ package chain
 import (
 	"context"
 	"fmt"
-	"strings"
+
+	"slices"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	codebaseApi "github.com/epam/edp-codebase-operator/v2/api/v1"
 
 	cdPipeApi "github.com/epam/edp-cd-pipeline-operator/v2/api/v1"
 	"github.com/epam/edp-cd-pipeline-operator/v2/internal/controller/stage/chain/util"
 	"github.com/epam/edp-cd-pipeline-operator/v2/pkg/util/cluster"
 )
 
+// RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate removes the
+// "<cdPipeline>/<stage>" environment label from every CodebaseImageStream that is
+// no longer referenced by the CDPipeline.
+//
+// PutEnvironmentLabelToCodebaseImageStreams only ever (re)labels the streams that
+// are currently in spec.inputDockerStreams, so when an application is removed from
+// a CDPipeline the label is orphaned on its CodebaseImageStream. codebase-operator
+// then keeps creating a CDStageDeploy for that stage on every new image tag, i.e.
+// it ghost-deploys an application that no longer belongs to the pipeline. This
+// handler reconciles the label set to the current spec so the orphan is cleaned up
+// regardless of how the application was removed (UI, kubectl or API).
 type RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate struct {
 	client client.Client
 }
-
-const dockerStreamsBeforeUpdateAnnotationKey = "deploy.edp.epam.com/docker-streams-before-update"
 
 func (h RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate) ServeRequest(
 	ctx context.Context,
 	stage *cdPipeApi.Stage,
 ) error {
 	log := ctrl.LoggerFrom(ctx)
+
 	if stage.IsManualTriggerType() {
-		log.Info("Trigger type is not auto deploy, skipping")
+		log.Info("Trigger type is not auto deploy, skipping cleanup of environment labels")
+
 		return nil
 	}
 
-	log.Info("start deleting environment labels from codebase image stream resources.")
+	log.Info("Start cleaning up stale environment labels from CodebaseImageStream resources")
 
 	pipe, err := util.GetCdPipeline(h.client, stage)
 	if err != nil {
-		return fmt.Errorf("failed to get %v cd pipeline: %w", stage.Spec.CdPipeline, err)
+		return fmt.Errorf("failed to get %s cd pipeline: %w", stage.Spec.CdPipeline, err)
 	}
 
-	annotations := pipe.GetAnnotations()[dockerStreamsBeforeUpdateAnnotationKey]
-	if annotations == "" {
-		log.Info("CodebaseImageStream doesn't contain %v annotation." +
-			" skip deleting env labels from CodebaseImageStream resources")
-
-		return nil
+	// Guard against an empty desired set wiping every labelled stream. The CRD
+	// enforces MinItems=1, but a bypassed/malformed spec must not trigger a purge.
+	if len(pipe.Spec.InputDockerStreams) == 0 {
+		return fmt.Errorf("pipeline %s doesn't contain codebase image streams", pipe.Name)
 	}
 
-	streams := strings.Split(annotations, ",")
-	for _, v := range streams {
-		stream, err := cluster.GetCodebaseImageStreamByCodebaseBaseBranchName(ctx, h.client, v, stage.Namespace)
-		if err != nil {
-			return fmt.Errorf("failed to get %v codebase image stream: %w", v, err)
+	envLabel := createLabelName(pipe.Name, stage.Spec.Name)
+
+	desired, err := h.desiredLabeledStreams(ctx, pipe, stage)
+	if err != nil {
+		return err
+	}
+
+	var streams codebaseApi.CodebaseImageStreamList
+	if err = h.client.List(
+		ctx,
+		&streams,
+		client.InNamespace(stage.Namespace),
+		client.HasLabels{envLabel},
+	); err != nil {
+		return fmt.Errorf("failed to list CodebaseImageStreams labeled %q: %w", envLabel, err)
+	}
+
+	for i := range streams.Items {
+		cis := &streams.Items[i]
+
+		// Only act on streams that actually carry the label. client.HasLabels
+		// silently widens the List to the whole namespace if envLabel is ever an
+		// invalid selector key, so this guard keeps us from updating unrelated streams.
+		if _, ok := cis.GetLabels()[envLabel]; !ok {
+			continue
 		}
 
-		env := fmt.Sprintf("%v/%v", pipe.Name, stage.Spec.Name)
-		deleteLabel(&stream.ObjectMeta, env)
-
-		if err := h.client.Update(context.Background(), stream); err != nil {
-			return fmt.Errorf("failed to update %v codebase image stream: %w", stream, err)
+		if _, ok := desired[cis.Name]; ok {
+			continue
 		}
+
+		deleteLabel(&cis.ObjectMeta, envLabel)
+
+		if err = h.client.Update(ctx, cis); err != nil {
+			return fmt.Errorf("failed to remove label %q from CodebaseImageStream %s: %w", envLabel, cis.Name, err)
+		}
+
+		log.Info("Stale environment label has been removed from CodebaseImageStream",
+			"label", envLabel, "codebaseImageStream", cis.Name)
 	}
 
-	log.Info("environment labels have been deleted from codebase image stream resources.")
+	log.Info("Stale environment labels have been cleaned up")
 
 	return nil
+}
+
+// desiredLabeledStreams returns the set of CodebaseImageStream names that must
+// carry the "<cdPipeline>/<stage>" label according to the current CDPipeline spec.
+// It mirrors PutEnvironmentLabelToCodebaseImageStreams: a first stage (or a
+// non-promoted application) labels the input stream itself, while a promoted
+// application on a non-first stage labels the upstream
+// "<cdPipeline>-<previousStage>-<codebase>-verified" stream.
+func (h RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate) desiredLabeledStreams(
+	ctx context.Context,
+	pipe *cdPipeApi.CDPipeline,
+	stage *cdPipeApi.Stage,
+) (map[string]struct{}, error) {
+	desired := make(map[string]struct{}, len(pipe.Spec.InputDockerStreams))
+
+	// previousStageName is identical for every promoted stream, so resolve it at
+	// most once and only when a promoted non-first stream actually needs it.
+	var (
+		previousStageName     string
+		previousStageResolved bool
+	)
+
+	for _, name := range pipe.Spec.InputDockerStreams {
+		stream, err := cluster.GetCodebaseImageStreamByCodebaseBaseBranchName(ctx, h.client, name, stage.Namespace)
+		if err != nil {
+			// Fail (and requeue) rather than skip: a transient resolve error must not
+			// drop a still-referenced stream from the desired set, or the caller would
+			// wrongly strip its label. This matches Put/DeleteEnvironmentLabel.
+			return nil, fmt.Errorf("failed to get %s codebase image stream: %w", name, err)
+		}
+
+		if stage.IsFirst() || !slices.Contains(pipe.Spec.ApplicationsToPromote, stream.Spec.Codebase) {
+			desired[stream.Name] = struct{}{}
+
+			continue
+		}
+
+		if !previousStageResolved {
+			previousStageName, err = util.FindPreviousStageName(ctx, h.client, stage)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get previous stage name: %w", err)
+			}
+
+			previousStageResolved = true
+		}
+
+		desired[createCisName(pipe.Name, previousStageName, stream.Spec.Codebase)] = struct{}{}
+	}
+
+	return desired, nil
 }

--- a/internal/controller/stage/chain/remove_labels_from_codebase_docker_streams_test.go
+++ b/internal/controller/stage/chain/remove_labels_from_codebase_docker_streams_test.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -20,113 +19,260 @@ import (
 	"github.com/epam/edp-cd-pipeline-operator/v2/pkg/util/cluster"
 )
 
-func createCdPipelineWithAnnotations(t *testing.T) cdPipeApi.CDPipeline {
-	t.Helper()
-
-	annotations := make(map[string]string)
-	annotations[dockerStreamsBeforeUpdateAnnotationKey] = dockerImageName
-
-	return cdPipeApi.CDPipeline{
+// cleanupStage builds a first (order 0) auto-deploy Stage with lowercase names so
+// the resulting "<pipeline>/<stage>" label is a valid Kubernetes label key.
+func cleanupStage(pipeName, stageName string) *cdPipeApi.Stage {
+	return &cdPipeApi.Stage{
 		ObjectMeta: metaV1.ObjectMeta{
-			Name:        cdPipeline,
-			Namespace:   namespace,
-			Annotations: annotations,
+			Name:      pipeName + "-" + stageName,
+			Namespace: namespace,
+		},
+		Spec: cdPipeApi.StageSpec{
+			Name:        stageName,
+			Order:       0,
+			CdPipeline:  pipeName,
+			TriggerType: cdPipeApi.TriggerTypeAutoDeploy,
 		},
 	}
 }
 
-func createCodebaseImageStreamWithLabels(t *testing.T) codebaseApi.CodebaseImageStream {
-	t.Helper()
-
-	labels := make(map[string]string)
-	labels[createLabelName(cdPipeline, name)] = labelValue
-	labels[cluster.CodebaseBranchLabel] = dockerImageName
-
-	return codebaseApi.CodebaseImageStream{
+func cleanupPipeline(pipeName string, inputStreams []string) *cdPipeApi.CDPipeline {
+	return &cdPipeApi.CDPipeline{
 		ObjectMeta: metaV1.ObjectMeta{
-			Name:      dockerImageName,
+			Name:      pipeName,
+			Namespace: namespace,
+		},
+		Spec: cdPipeApi.CDPipelineSpec{
+			Name:               pipeName,
+			InputDockerStreams: inputStreams,
+		},
+	}
+}
+
+// cisWithEnvLabel builds a CodebaseImageStream resolvable by its branch label and
+// carrying the given env label (an empty envLabel adds none).
+func cisWithEnvLabel(cisName, branch, codebaseName, envLabel string) *codebaseApi.CodebaseImageStream {
+	labels := map[string]string{cluster.CodebaseBranchLabel: branch}
+	if envLabel != "" {
+		labels[envLabel] = ""
+	}
+
+	return &codebaseApi.CodebaseImageStream{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      cisName,
 			Namespace: namespace,
 			Labels:    labels,
 		},
+		Spec: codebaseApi.CodebaseImageStreamSpec{
+			Codebase: codebaseName,
+		},
 	}
 }
 
-func TestRemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate_ServeRequest_Success(t *testing.T) {
-	stage := createStage(t, 0)
-	cdPipe := createCdPipelineWithAnnotations(t)
-	image := createCodebaseImageStreamWithLabels(t)
+// cisInputStream models a promoted application's input stream: resolvable by its branch
+// label but unlabelled, because PutEnvironmentLabel labels the verified stream instead.
+func cisInputStream(cisName, branch, codebaseName string) *codebaseApi.CodebaseImageStream {
+	return cisWithEnvLabel(cisName, branch, codebaseName, "")
+}
 
-	removeLabel := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
-		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).WithObjects(&stage, &cdPipe, &image).Build(),
+func hasEnvLabel(t *testing.T, c client.Client, cisName, envLabel string) bool {
+	t.Helper()
+
+	cis := &codebaseApi.CodebaseImageStream{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: cisName, Namespace: namespace}, cis))
+
+	_, ok := cis.GetLabels()[envLabel]
+
+	return ok
+}
+
+// The core regression test: an application removed from spec.inputDockerStreams must
+// have the "<pipeline>/<stage>" label stripped from its CodebaseImageStream, while a
+// stream that is still part of the pipeline keeps it.
+func TestRemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate_ServeRequest_PurgesOrphanKeepsMember(t *testing.T) {
+	pipeName, stageName := "demo", "dev"
+	envLabel := createLabelName(pipeName, stageName)
+
+	stage := cleanupStage(pipeName, stageName)
+	pipe := cleanupPipeline(pipeName, []string{"app-member-main"})
+	member := cisWithEnvLabel("app-member-main", "app-member-main", "app-member", envLabel)
+	orphan := cisWithEnvLabel("app-removed-main", "app-removed-main", "app-removed", envLabel)
+
+	h := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
+		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).
+			WithObjects(stage, pipe, member, orphan).Build(),
 	}
 
-	err := removeLabel.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), &stage)
-	assert.NoError(t, err)
+	require.NoError(t, h.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), stage))
 
-	currentImageStream := &codebaseApi.CodebaseImageStream{}
-	err = removeLabel.client.Get(
-		context.Background(),
-		client.ObjectKey{
-			Name:      dockerImageName,
-			Namespace: namespace,
-		},
-		currentImageStream,
-	)
-	require.NoError(t, err)
-	assert.Empty(t, currentImageStream.Labels[createLabelName(cdPipeline, name)])
+	assert.True(t, hasEnvLabel(t, h.client, "app-member-main", envLabel),
+		"stream still referenced by the pipeline must keep the env label")
+	assert.False(t, hasEnvLabel(t, h.client, "app-removed-main", envLabel),
+		"stream removed from the pipeline must lose the env label")
+}
+
+// Covers the !IsFirst() && promoted branch of desiredLabeledStreams: a promoted app on a
+// non-first stage is labelled on its upstream "<pipe>-<prevStage>-<codebase>-verified"
+// stream, so removing it must strip that verified stream while a still-promoted app keeps it.
+func TestRemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate_ServeRequest_PurgesOrphanVerifiedKeepsPromotedMember(t *testing.T) {
+	pipeName, prevStageName, stageName := "demo", "dev", "qa"
+	envLabel := createLabelName(pipeName, stageName)
+
+	// FindPreviousStageName resolves this order-0 stage by its pipeline label to build
+	// the "<pipe>-<prevStage>-<codebase>-verified" stream name.
+	prevStage := cleanupStage(pipeName, prevStageName)
+	prevStage.Labels = map[string]string{cdPipeApi.StageCdPipelineLabelName: pipeName}
+
+	stage := cleanupStage(pipeName, stageName)
+	stage.Spec.Order = 1
+	stage.Labels = map[string]string{cdPipeApi.StageCdPipelineLabelName: pipeName}
+
+	pipe := cleanupPipeline(pipeName, []string{"app-member-main"})
+	pipe.Spec.ApplicationsToPromote = []string{"app-member", "app-removed"}
+
+	// Surviving promoted app: input stream resolves the codebase, verified stream holds
+	// the label and must be preserved.
+	input := cisInputStream("app-member-main", "app-member-main", "app-member")
+	memberVerified := cisWithEnvLabel(
+		createCisName(pipeName, prevStageName, "app-member"), "app-member-verified", "app-member", envLabel)
+	orphanVerified := cisWithEnvLabel(
+		createCisName(pipeName, prevStageName, "app-removed"), "app-removed-verified", "app-removed", envLabel)
+
+	h := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
+		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).
+			WithObjects(prevStage, stage, pipe, input, memberVerified, orphanVerified).Build(),
+	}
+
+	require.NoError(t, h.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), stage))
+
+	assert.True(t, hasEnvLabel(t, h.client, memberVerified.Name, envLabel),
+		"verified stream of a still-promoted application must keep the env label")
+	assert.False(t, hasEnvLabel(t, h.client, orphanVerified.Name, envLabel),
+		"verified stream of a removed promoted application must lose the env label")
+}
+
+// Covers the !IsFirst() && !promoted branch of desiredLabeledStreams, which neither the
+// first-stage tests nor PurgesOrphanVerifiedKeepsPromotedMember reach: a non-promoted app
+// on a non-first stage is labelled on its input stream, not a verified one.
+func TestRemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate_ServeRequest_PurgesOrphanKeepsNonPromotedInputOnNonFirstStage(t *testing.T) {
+	pipeName, stageName := "demo", "qa"
+	envLabel := createLabelName(pipeName, stageName)
+
+	// Non-first, but app-keep isn't promoted, so its input stream is labelled directly
+	// and FindPreviousStageName is never needed.
+	stage := cleanupStage(pipeName, stageName)
+	stage.Spec.Order = 1
+
+	pipe := cleanupPipeline(pipeName, []string{"app-keep-main"})
+
+	member := cisWithEnvLabel("app-keep-main", "app-keep-main", "app-keep", envLabel)
+	orphan := cisWithEnvLabel(
+		createCisName(pipeName, "dev", "app-removed"), "app-removed-verified", "app-removed", envLabel)
+
+	h := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
+		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).
+			WithObjects(stage, pipe, member, orphan).Build(),
+	}
+
+	require.NoError(t, h.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), stage))
+
+	assert.True(t, hasEnvLabel(t, h.client, "app-keep-main", envLabel),
+		"input stream of a non-promoted app on a non-first stage must keep the env label")
+	assert.False(t, hasEnvLabel(t, h.client, orphan.Name, envLabel),
+		"stream no longer referenced by the pipeline must lose the env label")
+}
+
+// A manual-trigger stage never owns env labels, so the handler must leave everything untouched.
+func TestRemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate_ServeRequest_SkipManual(t *testing.T) {
+	pipeName, stageName := "demo", "dev"
+	envLabel := createLabelName(pipeName, stageName)
+
+	stage := cleanupStage(pipeName, stageName)
+	stage.Spec.TriggerType = cdPipeApi.TriggerTypeManual
+	pipe := cleanupPipeline(pipeName, []string{"app-member-main"})
+	orphan := cisWithEnvLabel("app-removed-main", "app-removed-main", "app-removed", envLabel)
+
+	h := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
+		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).
+			WithObjects(stage, pipe, orphan).Build(),
+	}
+
+	require.NoError(t, h.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), stage))
+
+	assert.True(t, hasEnvLabel(t, h.client, "app-removed-main", envLabel),
+		"manual-trigger stage must not modify any env labels")
+}
+
+// Re-running the handler when nothing was removed must be a no-op (idempotency).
+func TestRemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate_ServeRequest_NoOpWhenAllReferenced(t *testing.T) {
+	pipeName, stageName := "demo", "dev"
+	envLabel := createLabelName(pipeName, stageName)
+
+	stage := cleanupStage(pipeName, stageName)
+	pipe := cleanupPipeline(pipeName, []string{"app-a-main", "app-b-main"})
+	a := cisWithEnvLabel("app-a-main", "app-a-main", "app-a", envLabel)
+	b := cisWithEnvLabel("app-b-main", "app-b-main", "app-b", envLabel)
+
+	h := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
+		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).
+			WithObjects(stage, pipe, a, b).Build(),
+	}
+
+	require.NoError(t, h.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), stage))
+
+	assert.True(t, hasEnvLabel(t, h.client, "app-a-main", envLabel))
+	assert.True(t, hasEnvLabel(t, h.client, "app-b-main", envLabel))
 }
 
 func TestRemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate_ServeRequest_CantGetCdPipeline(t *testing.T) {
-	stage := createStage(t, 0)
+	stage := cleanupStage("demo", "dev")
 
-	removeLabel := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
-		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).WithObjects(&stage).Build(),
+	h := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
+		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).WithObjects(stage).Build(),
 	}
 
-	err := removeLabel.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), &stage)
+	err := h.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), stage)
+	require.Error(t, err)
 	assert.True(t, k8sErrors.IsNotFound(err))
 }
 
-func TestRemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate_ServeRequest_EmptyAnnotation(t *testing.T) {
-	stage := createStage(t, 0)
+// A failure to resolve a referenced input stream must NOT strip labels: the handler
+// errors (and requeues) instead, leaving every existing label intact.
+func TestRemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate_ServeRequest_ResolveErrorKeepsLabels(t *testing.T) {
+	pipeName, stageName := "demo", "dev"
+	envLabel := createLabelName(pipeName, stageName)
 
-	cdPipeline := createCdPipelineWithAnnotations(t)
-	cdPipeline.Annotations[dockerStreamsBeforeUpdateAnnotationKey] = ""
+	stage := cleanupStage(pipeName, stageName)
+	// References "app-member-main", but no CodebaseImageStream with that branch label
+	// exists, so resolution fails.
+	pipe := cleanupPipeline(pipeName, []string{"app-member-main"})
+	orphan := cisWithEnvLabel("app-removed-main", "app-removed-main", "app-removed", envLabel)
 
-	image := createCodebaseImageStreamWithLabels(t)
-
-	removeLabel := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
-		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).WithObjects(&stage, &cdPipeline, &image).Build(),
+	h := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
+		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).
+			WithObjects(stage, pipe, orphan).Build(),
 	}
 
-	err := removeLabel.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), &stage)
-	assert.NoError(t, err)
-
-	currentImageStream := &codebaseApi.CodebaseImageStream{}
-	err = removeLabel.client.Get(
-		context.Background(),
-		client.ObjectKey{
-			Name:      dockerImageName,
-			Namespace: namespace,
-		},
-		currentImageStream,
-	)
-	require.NoError(t, err)
-
-	assert.NoError(t, err)
-	assert.Equal(t, image.Labels, currentImageStream.Labels)
+	require.Error(t, h.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), stage))
+	assert.True(t, hasEnvLabel(t, h.client, "app-removed-main", envLabel),
+		"a resolve error must not strip any label")
 }
 
-func TestRemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate_ServeRequest_CantGetImageStream(t *testing.T) {
-	stage := createStage(t, 0)
+// An empty inputDockerStreams must not purge every labelled stream; the handler errors.
+func TestRemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate_ServeRequest_EmptyInputKeepsLabels(t *testing.T) {
+	pipeName, stageName := "demo", "dev"
+	envLabel := createLabelName(pipeName, stageName)
 
-	cdPipeline := createCdPipelineWithAnnotations(t)
+	stage := cleanupStage(pipeName, stageName)
+	pipe := cleanupPipeline(pipeName, nil)
+	orphan := cisWithEnvLabel("app-removed-main", "app-removed-main", "app-removed", envLabel)
 
-	removeLabel := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
-		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).WithObjects(&stage, &cdPipeline).Build(),
+	h := RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate{
+		client: fake.NewClientBuilder().WithScheme(schemeInit(t)).
+			WithObjects(stage, pipe, orphan).Build(),
 	}
 
-	err := removeLabel.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), &stage)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("failed to get %v codebase image stream", dockerImageName))
+	require.Error(t, h.ServeRequest(ctrl.LoggerInto(context.Background(), logr.Discard()), stage))
+	assert.True(t, hasEnvLabel(t, h.client, "app-removed-main", envLabel),
+		"an empty inputDockerStreams must not purge labels")
 }


### PR DESCRIPTION
## Problem

A stage with auto-deploy that holds two or more applications leaks a label when
one application is later removed from the `CDPipeline`. The
`<cdPipeline>/<stage>` environment label is **not** purged from the removed
application's `CodebaseImageStream`, so on every new image tag
codebase-operator keeps creating a `CDStageDeploy` for the stage the
application no longer belongs to — i.e. it **ghost-deploys** a removed
application into the old environment. The stale label never self-heals (it only
disappears when the whole Stage is deleted).

Reproduces identically via Portal "Edit deployment flow → remove app" and via
`kubectl patch cdpipeline`.

## Root cause

`internal/controller/stage/chain`:

- `RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate` depended on the
  `deploy.edp.epam.com/docker-streams-before-update` annotation, which nothing
  in the operator ever sets, so it always returned early (`if annotations == ""`).
- `DeleteEnvironmentLabelFromCodebaseImageStreams` only iterates the **current**
  `spec.inputDockerStreams`, so a stream that was removed from the list is never
  visited and its label is never deleted.

## Fix

Rework `RemoveLabelsFromCodebaseDockerStreamsAfterCdPipelineUpdate` to reconcile
the label set to the current `CDPipeline` spec instead of trusting a never-set
annotation:

1. Compute the desired set of streams that must carry the `<cdPipeline>/<stage>`
   label from the current `spec.inputDockerStreams` (mirroring
   `PutEnvironmentLabelToCodebaseImageStreams`, including the first-stage / promoted
   `<pipe>-<prevStage>-<codebase>-verified` cases).
2. List every `CodebaseImageStream` that currently carries the label.
3. Strip the label from any stream no longer in the desired set.

Idempotent, converges regardless of how the application was removed (UI / kubectl
/ API), and the manual-trigger skip is preserved.

## Testing

- `go build ./...` clean; `go test ./internal/controller/stage/chain/` passes,
  incl. new cases: purge-orphan/keep-member, skip-manual, idempotent no-op,
  can't-get-pipeline.
- **Live validation** on a kind cluster: scaled the in-cluster operator to 0 and
  ran the patched binary. On `demo-dev` reconcile it logged
  `Stale environment label has been removed … label="demo/dev" codebaseImageStream="test-go-app-2-main"`;
  the removed app's CIS converged to only its current label, the anchor app kept
  its label, and a subsequent image-tag bump produced **one** `CDStageDeploy`
  (the correct pipeline) instead of two — the ghost is gone.

